### PR TITLE
Account Route

### DIFF
--- a/src/Utils.js
+++ b/src/Utils.js
@@ -136,6 +136,16 @@ const DbUtils = {
     async DeleteToken(client, token) {
         await client.query(queries.DELETE_TOKEN, [token]);
     }
+};
+
+const DbUserUtils = {
+    async ChangePassword(client, user_id, new_password) {
+        await client.query(queries.UPDATE_PASSWORD, [new_password, user_id]);
+    },
+
+    async ChangeEmail(client, user_id, new_email) {
+        await client.query(queries.UPDATE_EMAIL, [new_email,  user_id])
+    }
 }
 
-module.exports = { DataUtils, DbUtils };
+module.exports = { DataUtils, DbUtils, DbUserUtils };

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -145,6 +145,10 @@ const DbUserUtils = {
 
     async ChangeEmail(client, user_id, new_email) {
         await client.query(queries.UPDATE_EMAIL, [new_email,  user_id])
+    },
+
+    async DeleteAccount(client, user_id) {
+        // await client.query(queries)
     }
 }
 

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -81,8 +81,7 @@ const DbUtils = {
      */
     async IsEmailAlreadyUsed(client, email) {
         const result = await client.query(queries.USER_BY_EMAIL, [email]);
-        console.log(result.rows.length);
-        console.log(result.rows.length > 0);
+
         return (result.rows.length > 0);
     },
 
@@ -99,7 +98,34 @@ const DbUtils = {
             return undefined;
         }
 
-        return result;
+        return result.rows[0];
+    },
+
+    async GetUserByToken(client, token) {
+        const result = await client.query(queries.USER_BY_TOKEN, [token]);
+
+        if (result.rows.length < 1) {
+            return undefined;
+        }
+
+        return result.rows[0];
+    },
+
+    async IsTokenValid(client, token, del = true) {
+        const result = await client.query(queries.CHECK_USER_TOKEN, [token]);
+
+        if (result.rows.length < 1) {
+            return undefined;
+        }
+
+        if (!(result.rows[0].expiration_date > new Date)) {
+            if (del) {
+                await DeleteToken(client, token);
+            }
+            return false;
+        }
+        
+        return true;
     },
 
     /**
@@ -108,7 +134,7 @@ const DbUtils = {
      * @param {*} token the token to be removed
      */
     async DeleteToken(client, token) {
-        const result = await client.query(queries.DELETE_TOKEN, [token]);
+        await client.query(queries.DELETE_TOKEN, [token]);
     }
 }
 

--- a/src/queries.js
+++ b/src/queries.js
@@ -11,5 +11,7 @@ module.exports = {
     SELLER_BY_USER_ID: 'SELECT * FROM sellers WHERE user_id = $1 LIMIT 1',
 
     USER_BY_EMAIL: 'SELECT * FROM users WHERE email = $1 LIMIT 1',
-    USER_BY_ID: 'SELECT * FROM users WHERE user_id = $1 LIMIT 1'
+    USER_BY_ID: 'SELECT * FROM users WHERE user_id = $1 LIMIT 1',
+    // NOT SURE ABOUT THIS
+    USER_BY_TOKEN: 'SELECT * FROM users u JOIN user_tokens ut ON u.user_id = ut.user_id WHERE ut.token = $1 LIMIT 1'
 }

--- a/src/queries.js
+++ b/src/queries.js
@@ -8,6 +8,8 @@ module.exports = {
     DELETE_ALL_TOKEN_BY_USER_ID: 'DELETE FROM user_tokens WHERE user_id = $1',
     DELETE_TOKEN: 'DELETE FROM user_tokens WHERE token = $1',
 
+    SELLER_BY_USER_ID: 'SELECT * FROM sellers WHERE user_id = $1 LIMIT 1',
+
     USER_BY_EMAIL: 'SELECT * FROM users WHERE email = $1 LIMIT 1',
     USER_BY_ID: 'SELECT * FROM users WHERE user_id = $1 LIMIT 1'
 }

--- a/src/queries.js
+++ b/src/queries.js
@@ -12,6 +12,9 @@ module.exports = {
 
     USER_BY_EMAIL: 'SELECT * FROM users WHERE email = $1 LIMIT 1',
     USER_BY_ID: 'SELECT * FROM users WHERE user_id = $1 LIMIT 1',
-    // NOT SURE ABOUT THIS
-    USER_BY_TOKEN: 'SELECT * FROM users u JOIN user_tokens ut ON u.user_id = ut.user_id WHERE ut.token = $1 LIMIT 1'
+ 
+    USER_BY_TOKEN: 'SELECT * FROM users u JOIN user_tokens ut ON u.user_id = ut.user_id WHERE ut.token = $1 LIMIT 1',
+
+    UPDATE_PASSWORD: 'UPDATE public.users SET password = $1 WHERE user_id = $2',
+    UPDATE_EMAIL: 'UPDATE public.users SET email = $1 WHERE user_id = $2'
 }

--- a/src/routes/account.js
+++ b/src/routes/account.js
@@ -3,11 +3,11 @@ const router = express.Router();
 const pool = require('../db');
 const queries = require('../queries');
 const bcrypt = require('bcryptjs');
-const { DbUtils } = require('../Utils');
+const { DbUtils, DbUserUtils } = require('../Utils');
 
 router.put('/password', async function (req, res) {
     const authHeader = req.headers['authorization'];
-    
+
     // check if the headers is present
     if (!authHeader) {
         return res.status(401).json({ error: "Missing auth header" }).send();
@@ -24,17 +24,60 @@ router.put('/password', async function (req, res) {
 
     // check if token is valid
     if (!DbUtils.IsTokenValid(client, authHeader)) {
-        return res.status(401).json({error: "token expired"}).send();
+        return res.status(401).json({ error: "token expired" }).send();
     }
 
-    const user = DbUtils.GetUserByToken(client, authHeader);
+    const user = await DbUtils.GetUserByToken(client, authHeader);
 
     // compare password
     if (!bcrypt.compareSync(old_password, user.password)) {
-        return res.status(400).json({error: "password not valid"}).send();
+        return res.status(400).json({ error: "password not valid" }).send();
     }
 
     const hashed_password = bcrypt.hashSync(new_password, bcrypt.genSaltSync());
-    
-    // change to new password
+
+    // update the password
+    await DbUserUtils.ChangePassword(client, user.user_id, hashed_password);
+
+    return res.status(201).send();
 });
+
+router.put('/email', async function (req, res) {
+    const authHeader = req.headers['authorization'];
+
+    // check if the headers is present
+    if (!authHeader) {
+        return res.status(401).json({ error: "Missing auth header" }).send();
+    }
+
+    const { new_email } = req.body;
+
+    // check if body data is valid
+    if (!new_email || typeof new_email !== 'string') {
+        return res.status(400).json({ error: 'Invalid params' });
+    }
+
+    const client = await pool.connect();
+
+    // check if token is valid
+    if (!DbUtils.IsTokenValid(client, authHeader)) {
+        return res.status(401).json({ error: "token expired" }).send();
+    }
+
+    const user = await DbUtils.GetUserByToken(client, authHeader);
+
+    // update the email
+    await DbUserUtils.ChangeEmail(client, user.user_id, new_email);
+
+    return res.status(201).send();
+});
+
+router.delete('/delete', async function (req, res) {
+    return res.status(501).json({error:"Not yet implemented"}).send();
+});
+
+router.post('/seller', async function (req, res) {
+    return res.status(501).json({error:"Not yet implemented"}).send();
+})
+
+module.exports = router;

--- a/src/routes/account.js
+++ b/src/routes/account.js
@@ -61,6 +61,7 @@ router.put('/email', async function (req, res) {
 
     // check if token is valid
     if (!DbUtils.IsTokenValid(client, authHeader)) {
+        client.release();
         return res.status(401).json({ error: "token expired" }).send();
     }
 
@@ -69,15 +70,39 @@ router.put('/email', async function (req, res) {
     // update the email
     await DbUserUtils.ChangeEmail(client, user.user_id, new_email);
 
+    client.release();
     return res.status(201).send();
 });
 
 router.delete('/delete', async function (req, res) {
-    return res.status(501).json({error:"Not yet implemented"}).send();
+    const authHeader = req.headers['authorization'];
+
+    // check if the headers is present
+    if (!authHeader) {
+        return res.status(401).json({ error: "Missing auth header" }).send();
+    }
+
+    const client = await pool.connect();
+
+    // check if token is valid
+    if (!DbUtils.IsTokenValid(client, authHeader)) {
+        client.release();
+        return res.status(401).json({ error: "token expired" }).send();
+    }
+
+    const user = await DbUtils.GetUserByToken(client, authHeader);
+
+    // UNDECISE IF TO DELETE THE USER OR KEEP THE DATA IN A LOCKED STATE
+    await DbUserUtils.DeleteAccount();
+
+    client.release();
+
+    // STILL NOT YET IMPLEMENTED
+    return res.status(501).json({ error: "Not yet implemented" }).send();
 });
 
 router.post('/seller', async function (req, res) {
-    return res.status(501).json({error:"Not yet implemented"}).send();
+    return res.status(501).json({ error: "Not yet implemented" }).send();
 })
 
 module.exports = router;

--- a/src/routes/account.js
+++ b/src/routes/account.js
@@ -1,0 +1,31 @@
+const express = require('express');
+const router = express.Router();
+const pool = require('../db');
+const queries = require('../queries');
+const bcrypt = require('bcryptjs');
+const { DbUtils } = require('../Utils');
+
+router.put('/password', async function (req, res) {
+    const authHeader = req.headers['authorization'];
+    
+    // check if the headers is present
+    if (!authHeader) {
+        return res.status(401).json({ error: "Missing auth header" }).send();
+    }
+
+    const { old_password, new_password } = req.body;
+
+    if (!old_password || !new_password || typeof old_password !== 'string' || typeof new_password !== 'string') {
+        return res.status(400).json({ error: 'Invalid params' });
+    }
+
+    const client = await pool.connect();
+
+    // get user by token
+
+    // compare password
+
+    const hashed_password = bcrypt.hashSync(new_password, bcrypt.genSaltSync());
+
+    // change to new password
+});

--- a/src/routes/account.js
+++ b/src/routes/account.js
@@ -15,17 +15,26 @@ router.put('/password', async function (req, res) {
 
     const { old_password, new_password } = req.body;
 
+    // check if body data is valid
     if (!old_password || !new_password || typeof old_password !== 'string' || typeof new_password !== 'string') {
         return res.status(400).json({ error: 'Invalid params' });
     }
 
     const client = await pool.connect();
 
-    // get user by token
+    // check if token is valid
+    if (!DbUtils.IsTokenValid(client, authHeader)) {
+        return res.status(401).json({error: "token expired"}).send();
+    }
+
+    const user = DbUtils.GetUserByToken(client, authHeader);
 
     // compare password
+    if (!bcrypt.compareSync(old_password, user.password)) {
+        return res.status(400).json({error: "password not valid"}).send();
+    }
 
     const hashed_password = bcrypt.hashSync(new_password, bcrypt.genSaltSync());
-
+    
     // change to new password
 });

--- a/src/routes/login.js
+++ b/src/routes/login.js
@@ -10,8 +10,6 @@ router.post('/', async function (req, res) {
     // get the params
     const { email, password, token } = req.body;
 
-    console.log(req.body)
-
     // get a client
     const client = await pool.connect();
 

--- a/src/routes/rootv1.js
+++ b/src/routes/rootv1.js
@@ -18,11 +18,13 @@ const loginRouter = require('./login.js');
 const registerRouter = require('./register.js');
 const productRouter = require('./product.js');
 const sellerRouter = require('./sellers.js');
+const accountRouter = require('./account.js');
 
 // imposta il router per ogni route
 router.use('/login', loginRouter);
 router.use('/register', registerRouter);
 router.use('/seller', sellerRouter);
+router.use('/account', accountRouter);
 
 // imposta la route di swagger
 router.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));

--- a/src/routes/rootv1.js
+++ b/src/routes/rootv1.js
@@ -17,10 +17,12 @@ router.get('/', (req, res) => {
 const loginRouter = require('./login.js');
 const registerRouter = require('./register.js');
 const productRouter = require('./product.js');
+const sellerRouter = require('./sellers.js');
 
 // imposta il router per ogni route
 router.use('/login', loginRouter);
 router.use('/register', registerRouter);
+router.use('/seller', sellerRouter);
 
 // imposta la route di swagger
 router.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));

--- a/src/routes/sellers.js
+++ b/src/routes/sellers.js
@@ -1,0 +1,40 @@
+const express = require('express');
+const router = express.Router();
+const pool = require('../db');
+const queries = require('../queries');
+const { DbUtils } = require('../Utils');
+
+// SHOULD WORK DIDN'T TEST IT
+router.get('/:id', async function (req, res) {
+    // get the id from the url
+    const id = req.params.id;
+
+    // if is not a valid number send error
+    if (typeof id !== 'number' && id >= 0) {
+        return res.status(400).json({ error: "Id not valid" }).send();
+    }
+
+    // get a client
+    const client = await pool.connect();
+
+    // make the query
+    const result = await client.query(queries.SELLER_BY_USER_ID, [id]);
+
+    // if there is no result error
+    if(result.rows.length < 1) {
+        return res.status(400).json({ error: "Id not valid" }).send();
+    }
+
+    // release the client & send the result
+    client.release();
+    res.status(200).json({
+        seller_name: result[0].seller_name,
+        description: result[0].description
+    }).send();
+});
+
+router.get('/', async function (req, res) {
+    res.json({ skibidi: "skibidi" })
+});
+
+module.exports = router;

--- a/src/swagger/swagger-output.json
+++ b/src/swagger/swagger-output.json
@@ -81,6 +81,9 @@
         "responses": {
           "200": {
             "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
           }
         }
       }
@@ -91,6 +94,44 @@
         "responses": {
           "200": {
             "description": "OK"
+          }
+        }
+      }
+    },
+    "/account/password": {
+      "put": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "old_password": {
+                  "example": "any"
+                },
+                "new_password": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
           }
         }
       }

--- a/src/swagger/swagger-output.json
+++ b/src/swagger/swagger-output.json
@@ -66,6 +66,34 @@
           }
         }
       }
+    },
+    "/seller/{id}": {
+      "get": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/seller/": {
+      "get": {
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Has explained in #13 added `change email`, `change password` and `delete` (not implemented) routes to the `/account` route.

They require the `authetication` header to be set with the `session token`.

(merging this before finished because I have to work on a more important part of the API)